### PR TITLE
Add reporting modules and receipt printing

### DIFF
--- a/ggs_accounting/models/reporting.py
+++ b/ggs_accounting/models/reporting.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ggs_accounting.db.db_manager import DatabaseManager
+
+
+BUILT_IN_QUERIES: dict[str, str] = {
+    "Outstanding Balances": "SELECT name, balance FROM Parties WHERE balance <> 0",
+    "Top Selling Items": (
+        "SELECT item_id, SUM(quantity) AS total_sold\n"
+        "FROM InvoiceItems\n"
+        "JOIN Invoices ON Invoices.inv_id = InvoiceItems.inv_id\n"
+        "WHERE Invoices.date >= date('now', '-30 days') AND Invoices.type = 'Sale'\n"
+        "GROUP BY item_id\n"
+        "ORDER BY total_sold DESC"
+    ),
+    "Low Stock Items": "SELECT item_name AS name, stock_qty FROM Items WHERE stock_qty < 10",
+    "Recent Sales": (
+        "SELECT date, total_amount FROM Invoices\n"
+        "WHERE type = 'Sale'\n"
+        "ORDER BY date DESC LIMIT 10"
+    ),
+    "High Value Customers": (
+        "SELECT Parties.name, SUM(Invoices.total_amount) as total_spent\n"
+        "FROM Invoices JOIN Parties ON Invoices.party_id = Parties.party_id\n"
+        "WHERE Invoices.type = 'Sale'\n"
+        "GROUP BY Parties.name\n"
+        "ORDER BY total_spent DESC"
+    ),
+}
+
+
+def run_query(db: DatabaseManager, sql: str) -> Tuple[List[str], List[tuple]]:
+    """Execute SQL via DatabaseManager ensuring it's a SELECT."""
+    return db.run_raw_query(sql)
+
+
+def get_party_balances(db: DatabaseManager) -> List[Dict[str, Any]]:
+    cur = db.conn.cursor()
+    cur.execute("SELECT name, balance FROM Parties")
+    rows = cur.fetchall()
+    result: List[Dict[str, Any]] = []
+    for row in rows:
+        bal = float(row["balance"])
+        status = "Receivable" if bal > 0 else "Payable" if bal < 0 else "Settled"
+        result.append({"name": row["name"], "balance": bal, "status": status})
+    return result
+
+
+def get_inventory_values(db: DatabaseManager) -> Tuple[List[Dict[str, Any]], float]:
+    cur = db.conn.cursor()
+    cur.execute("SELECT name, stock_qty, price_excl_tax FROM Items")
+    rows = cur.fetchall()
+    total_value = 0.0
+    result: List[Dict[str, Any]] = []
+    for row in rows:
+        value = float(row["stock_qty"] * row["price_excl_tax"])
+        total_value += value
+        result.append(
+            {
+                "name": row["name"],
+                "stock": row["stock_qty"],
+                "price": row["price_excl_tax"],
+                "value": value,
+            }
+        )
+    return result, total_value

--- a/ggs_accounting/printing/print_receipts.py
+++ b/ggs_accounting/printing/print_receipts.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import webbrowser
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Table, TableStyle
+
+from ggs_accounting.db.db_manager import DatabaseManager
+
+
+class ReceiptPrinter:
+    """Generate simple PDF invoices or summaries."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        self._db = db
+
+    # ---- query helpers ----
+    def fetch_invoices(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        party_id: Optional[int] = None,
+        inv_type: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        invoices = self._db.get_invoices(start_date, end_date)
+        result: List[Dict[str, Any]] = []
+        for inv in invoices:
+            if party_id and inv["party_id"] != party_id:
+                continue
+            if inv_type and inv["type"] != inv_type:
+                continue
+            result.append(inv)
+        return result
+
+    # ---- pdf helpers ----
+    def _summary_table(self, invoices: Iterable[Dict[str, Any]]) -> Table:
+        data = [["Date", "Invoice", "Party", "Total"]]
+        parties = {p["party_id"]: p["name"] for p in self._db.get_all_parties()}
+        for inv in invoices:
+            data.append([
+                inv["date"],
+                str(inv["inv_id"]),
+                parties.get(inv["party_id"], ""),
+                f"{inv['total_amount']:.2f}",
+            ])
+        table = Table(data, colWidths=[80, 60, 200, 80])
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ]
+            )
+        )
+        return table
+
+    def print_summary(self, invoices: Iterable[Dict[str, Any]]) -> str:
+        """Generate a summary PDF and open it."""
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+        doc = SimpleDocTemplate(tmp.name, pagesize=A4)
+        styles = getSampleStyleSheet()
+        story = [Paragraph("Invoice Summary", styles["Title"]), self._summary_table(invoices)]
+        doc.build(story)
+        webbrowser.open(tmp.name)
+        return tmp.name
+
+    def print_detailed(self, invoices: Iterable[Dict[str, Any]]) -> str:
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+        doc = SimpleDocTemplate(tmp.name, pagesize=A4)
+        styles = getSampleStyleSheet()
+        parties = {p["party_id"]: p for p in self._db.get_all_parties()}
+        story = []
+        for inv in invoices:
+            party = parties.get(inv["party_id"], {})
+            story.append(Paragraph(f"Invoice {inv['inv_id']}", styles["Heading2"]))
+            story.append(Paragraph(f"Date: {inv['date']}", styles["Normal"]))
+            if party:
+                story.append(Paragraph(f"Party: {party.get('name')}", styles["Normal"]))
+            items = self._db.get_invoice_items(inv["inv_id"])
+            data = [["Item", "Qty", "Price", "Total"]]
+            for it in items:
+                data.append(
+                    [
+                        str(it["item_id"]),
+                        str(it["quantity"]),
+                        f"{it['unit_price']:.2f}",
+                        f"{it['line_total']:.2f}",
+                    ]
+                )
+            tbl = Table(data, colWidths=[100, 60, 80, 80])
+            tbl.setStyle(
+                TableStyle(
+                    [
+                        ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                        ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                    ]
+                )
+            )
+            story.append(tbl)
+            story.append(Paragraph(" ", styles["Normal"]))
+        doc.build(story)
+        webbrowser.open(tmp.name)
+        return tmp.name

--- a/ggs_accounting/ui/invoice_panel.py
+++ b/ggs_accounting/ui/invoice_panel.py
@@ -29,13 +29,18 @@ class InvoicePanel(QtWidgets.QWidget):
         self.type_combo.addItems(["Sale", "Purchase"])
 
         self.party_combo = QtWidgets.QComboBox()
+        add_party_btn = QtWidgets.QPushButton("Add Party")
+        add_party_btn.clicked.connect(self._add_party)
+        party_layout = QtWidgets.QHBoxLayout()
+        party_layout.addWidget(self.party_combo)
+        party_layout.addWidget(add_party_btn)
 
         self.date_edit = QtWidgets.QDateEdit()
         self.date_edit.setCalendarPopup(True)
         self.date_edit.setDate(date.today())
 
         form.addRow("Type", self.type_combo)
-        form.addRow("Party", self.party_combo)
+        form.addRow("Party", party_layout)
         form.addRow("Date", self.date_edit)
         layout.addLayout(form)
 
@@ -78,6 +83,17 @@ class InvoicePanel(QtWidgets.QWidget):
         except Exception as exc:  # pragma: no cover
             QtWidgets.QMessageBox.critical(self, "Error", str(exc))
             self._items = []
+
+    def _add_party(self) -> None:
+        from .party_dialog import PartyDialog
+
+        dlg = PartyDialog(self._db)
+        if dlg.exec() == QtWidgets.QDialog.DialogCode.Accepted:
+            self._load_parties()
+            # select last added party
+            parties = self._db.get_all_parties()
+            if parties:
+                self.party_combo.setCurrentIndex(len(parties))
 
     # ---- Table helpers ----
     def _add_line(self) -> None:

--- a/ggs_accounting/ui/main_window.py
+++ b/ggs_accounting/ui/main_window.py
@@ -2,6 +2,7 @@ from PyQt6 import QtWidgets
 from PyQt6.QtCore import Qt, pyqtSignal
 
 from ggs_accounting.models.auth import UserRole
+from ggs_accounting.db.db_manager import DatabaseManager
 
 class MainWindow(QtWidgets.QMainWindow):
     """Main application shell."""
@@ -9,8 +10,9 @@ class MainWindow(QtWidgets.QMainWindow):
     logout_requested = pyqtSignal()
     exit_requested = pyqtSignal()  # Add a new signal for exit
 
-    def __init__(self, user_role: str) -> None:
+    def __init__(self, db: DatabaseManager, user_role: str) -> None:
         super().__init__()
+        self._db = db
         self._role = UserRole(user_role)
         self.setWindowTitle("Wholesale Billing System")
         self.resize(800, 600)
@@ -38,10 +40,23 @@ class MainWindow(QtWidgets.QMainWindow):
         exit_action.triggered.connect(self._handle_exit)
 
     def _init_tabs(self) -> None:
-        for name in ["Inventory", "Billing", "Reports", "Backup"]:
-            self._stack.addTab(self._create_placeholder(name), name)
+        from .inventory_panel import InventoryPanel
+        from .invoice_panel import InvoicePanel
+        from .receipt_console import ReceiptConsole
+        from .reports_panel import ReportsPanel
+        from .reports_party_balance import PartyBalancePanel
+        from .reports_inventory import InventoryValuationPanel
+        from .settings_panel import SettingsPanel
+
+        self._stack.addTab(InventoryPanel(self._db), "Inventory")
+        self._stack.addTab(InvoicePanel(self._db), "Billing")
+        self._stack.addTab(ReceiptConsole(self._db), "Receipts")
+        self._stack.addTab(ReportsPanel(self._db), "SQL")
+        self._stack.addTab(PartyBalancePanel(self._db), "Party Balances")
+        self._stack.addTab(InventoryValuationPanel(self._db), "Inventory Value")
+        self._stack.addTab(self._create_placeholder("Backup"), "Backup")
         if self._role is UserRole.ADMIN:
-            settings_widget = self._create_placeholder("Settings")
+            settings_widget = SettingsPanel(self._db)
             self._settings_index = self._stack.addTab(settings_widget, "Settings")
 
     def _create_placeholder(self, title: str) -> QtWidgets.QWidget:

--- a/ggs_accounting/ui/party_dialog.py
+++ b/ggs_accounting/ui/party_dialog.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from PyQt6 import QtWidgets
+
+from ggs_accounting.db.db_manager import DatabaseManager
+
+
+class PartyDialog(QtWidgets.QDialog):
+    """Dialog for adding a new party."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        super().__init__()
+        self._db = db
+        self.setWindowTitle("Add Party")
+
+        self.name_edit = QtWidgets.QLineEdit()
+        self.contact_edit = QtWidgets.QLineEdit()
+
+        form = QtWidgets.QFormLayout()
+        form.addRow("Name", self.name_edit)
+        form.addRow("Contact", self.contact_edit)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(buttons)
+
+    def accept(self) -> None:  # type: ignore[override]
+        name = self.name_edit.text().strip()
+        if not name:
+            QtWidgets.QMessageBox.warning(self, "Validation", "Name required")
+            return
+        try:
+            self._db.add_party(name, self.contact_edit.text().strip())
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        super().accept()

--- a/ggs_accounting/ui/receipt_console.py
+++ b/ggs_accounting/ui/receipt_console.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from PyQt6 import QtWidgets
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.printing.print_receipts import ReceiptPrinter
+
+
+class ReceiptConsole(QtWidgets.QWidget):
+    """Simple UI to filter and print invoices."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        super().__init__()
+        self._db = db
+        self._printer = ReceiptPrinter(db)
+        self._init_ui()
+        self._load_parties()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+
+        form = QtWidgets.QFormLayout()
+        self.from_date = QtWidgets.QDateEdit()
+        self.from_date.setCalendarPopup(True)
+        self.to_date = QtWidgets.QDateEdit()
+        self.to_date.setCalendarPopup(True)
+        self.from_date.setDate(date.today())
+        self.to_date.setDate(date.today())
+        self.party_combo = QtWidgets.QComboBox()
+        self.party_combo.addItem("All", None)
+        self.type_combo = QtWidgets.QComboBox()
+        self.type_combo.addItems(["All", "Sale", "Purchase"])
+        self.format_combo = QtWidgets.QComboBox()
+        self.format_combo.addItems(["Detailed", "Summary"])
+
+        form.addRow("From", self.from_date)
+        form.addRow("To", self.to_date)
+        form.addRow("Party", self.party_combo)
+        form.addRow("Type", self.type_combo)
+        form.addRow("Format", self.format_combo)
+        layout.addLayout(form)
+
+        btns = QtWidgets.QHBoxLayout()
+        show_btn = QtWidgets.QPushButton("Show")
+        print_btn = QtWidgets.QPushButton("Print")
+        show_btn.clicked.connect(self._show)
+        print_btn.clicked.connect(self._print)
+        btns.addWidget(show_btn)
+        btns.addWidget(print_btn)
+        layout.addLayout(btns)
+
+        self.summary_table = QtWidgets.QTableWidget(0, 4)
+        self.summary_table.setHorizontalHeaderLabels(["Date", "Invoice", "Party", "Total"])
+        self.summary_table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.summary_table)
+
+    def _load_parties(self) -> None:
+        self.party_combo.clear()
+        self.party_combo.addItem("All", None)
+        try:
+            parties = self._db.get_all_parties()
+        except Exception as exc:  # pragma: no cover
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        for p in parties:
+            self.party_combo.addItem(p["name"], p["party_id"])
+
+    def _fetch(self) -> list:
+        start = self.from_date.date().toString("yyyy-MM-dd")
+        end = self.to_date.date().toString("yyyy-MM-dd")
+        party = self.party_combo.currentData()
+        inv_type = self.type_combo.currentText()
+        if inv_type == "All":
+            inv_type = None
+        return self._printer.fetch_invoices(start, end, party, inv_type)
+
+    def _show(self) -> None:
+        invoices = self._fetch()
+        self.summary_table.setRowCount(len(invoices))
+        parties = {p["party_id"]: p["name"] for p in self._db.get_all_parties()}
+        for row, inv in enumerate(invoices):
+            self.summary_table.setItem(row, 0, QtWidgets.QTableWidgetItem(inv["date"]))
+            self.summary_table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(inv["inv_id"])))
+            self.summary_table.setItem(row, 2, QtWidgets.QTableWidgetItem(parties.get(inv["party_id"], "")))
+            self.summary_table.setItem(row, 3, QtWidgets.QTableWidgetItem(f"{inv['total_amount']:.2f}"))
+        self.summary_table.resizeColumnsToContents()
+
+    def _print(self) -> None:
+        invoices = self._fetch()
+        if not invoices:
+            QtWidgets.QMessageBox.information(self, "No Data", "No invoices found")
+            return
+        fmt = self.format_combo.currentText()
+        if fmt == "Summary":
+            self._printer.print_summary(invoices)
+        else:
+            self._printer.print_detailed(invoices)

--- a/ggs_accounting/ui/reports_inventory.py
+++ b/ggs_accounting/ui/reports_inventory.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from PyQt6 import QtWidgets
+import pandas as pd
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.models.reporting import get_inventory_values
+
+
+class InventoryValuationPanel(QtWidgets.QWidget):
+    """Report showing inventory valuation."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        super().__init__()
+        self._db = db
+        self._init_ui()
+        self._load_data()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        btns = QtWidgets.QHBoxLayout()
+        refresh_btn = QtWidgets.QPushButton("Refresh")
+        export_btn = QtWidgets.QPushButton("Export")
+        refresh_btn.clicked.connect(self._load_data)
+        export_btn.clicked.connect(self._export)
+        btns.addWidget(refresh_btn)
+        btns.addWidget(export_btn)
+        layout.addLayout(btns)
+
+        self.table = QtWidgets.QTableWidget(0, 4)
+        self.table.setHorizontalHeaderLabels(["Item", "Stock", "Price", "Value"])
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        self.total_label = QtWidgets.QLabel()
+        layout.addWidget(self.total_label)
+
+    def _load_data(self) -> None:
+        try:
+            data, total = get_inventory_values(self._db)
+        except Exception as exc:  # pragma: no cover
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        self.table.setRowCount(len(data))
+        for row, item in enumerate(data):
+            self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(item["name"]))
+            self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(item["stock"])))
+            self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(f"{item['price']:.2f}"))
+            self.table.setItem(row, 3, QtWidgets.QTableWidgetItem(f"{item['value']:.2f}"))
+        self.table.resizeColumnsToContents()
+        self.total_label.setText(f"Total Stock Value: {total:.2f}")
+        self._data = data
+
+    def _export(self) -> None:
+        if not getattr(self, "_data", None):
+            return
+        df = pd.DataFrame(self._data)
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Export", filter="Excel Files (*.xlsx)")
+        if path:
+            try:
+                df.to_excel(path, index=False)
+            except Exception as exc:  # pragma: no cover
+                QtWidgets.QMessageBox.critical(self, "Error", str(exc))

--- a/ggs_accounting/ui/reports_panel.py
+++ b/ggs_accounting/ui/reports_panel.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import List
+
+from PyQt6 import QtWidgets
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.models import reporting
+
+
+class ReportsPanel(QtWidgets.QWidget):
+    """SQL console with saved queries and templates."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        super().__init__()
+        self._db = db
+        self._init_ui()
+        self._load_saved()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+
+        top = QtWidgets.QHBoxLayout()
+        self.template_combo = QtWidgets.QComboBox()
+        self.template_combo.addItem("Select Template", "")
+        for name in reporting.BUILT_IN_QUERIES:
+            self.template_combo.addItem(name)
+        self.template_combo.currentTextChanged.connect(self._apply_template)
+
+        self.saved_combo = QtWidgets.QComboBox()
+        self.saved_combo.currentIndexChanged.connect(self._load_saved_query)
+
+        self.name_edit = QtWidgets.QLineEdit()
+        run_btn = QtWidgets.QPushButton("Run")
+        save_btn = QtWidgets.QPushButton("Save")
+        run_btn.clicked.connect(self._run_query)
+        save_btn.clicked.connect(self._save_query)
+
+        top.addWidget(self.template_combo)
+        top.addWidget(self.saved_combo)
+        top.addWidget(self.name_edit)
+        top.addWidget(save_btn)
+        top.addWidget(run_btn)
+        layout.addLayout(top)
+
+        self.sql_edit = QtWidgets.QPlainTextEdit()
+        self.sql_edit.setPlaceholderText("SELECT ...")
+        layout.addWidget(self.sql_edit)
+
+        self.table = QtWidgets.QTableWidget(0, 0)
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        layout.addWidget(self.table)
+
+    def _apply_template(self, name: str) -> None:
+        sql = reporting.BUILT_IN_QUERIES.get(name)
+        if sql:
+            self.sql_edit.setPlainText(sql)
+
+    def _load_saved(self) -> None:
+        self.saved_combo.clear()
+        self.saved_combo.addItem("Saved Queries", None)
+        try:
+            queries = self._db.get_saved_queries()
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        for q in queries:
+            self.saved_combo.addItem(q["name"], q["sql"])
+
+    def _load_saved_query(self) -> None:
+        sql = self.saved_combo.currentData()
+        if sql:
+            self.sql_edit.setPlainText(str(sql))
+
+    def _run_query(self) -> None:
+        sql = self.sql_edit.toPlainText().strip()
+        if not sql:
+            return
+        try:
+            cols, rows = reporting.run_query(self._db, sql)
+        except Exception as exc:  # pragma: no cover
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        self.table.setColumnCount(len(cols))
+        self.table.setHorizontalHeaderLabels([str(c) for c in cols])
+        self.table.setRowCount(len(rows))
+        for r, row in enumerate(rows):
+            for c, val in enumerate(row):
+                self.table.setItem(r, c, QtWidgets.QTableWidgetItem(str(val)))
+        self.table.resizeColumnsToContents()
+
+    def _save_query(self) -> None:
+        name = self.name_edit.text().strip()
+        sql = self.sql_edit.toPlainText().strip()
+        if not name or not sql:
+            return
+        try:
+            self._db.save_query(name, sql)
+        except Exception as exc:  # pragma: no cover
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        self._load_saved()

--- a/ggs_accounting/ui/reports_party_balance.py
+++ b/ggs_accounting/ui/reports_party_balance.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from PyQt6 import QtWidgets
+import pandas as pd
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.models.reporting import get_party_balances
+
+
+class PartyBalancePanel(QtWidgets.QWidget):
+    """Display party-wise outstanding balances."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        super().__init__()
+        self._db = db
+        self._init_ui()
+        self._load_data()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        btns = QtWidgets.QHBoxLayout()
+        refresh_btn = QtWidgets.QPushButton("Refresh")
+        export_btn = QtWidgets.QPushButton("Export")
+        refresh_btn.clicked.connect(self._load_data)
+        export_btn.clicked.connect(self._export)
+        btns.addWidget(refresh_btn)
+        btns.addWidget(export_btn)
+        layout.addLayout(btns)
+
+        self.table = QtWidgets.QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["Party", "Balance", "Status"])
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+    def _load_data(self) -> None:
+        try:
+            data = get_party_balances(self._db)
+        except Exception as exc:  # pragma: no cover
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        self.table.setRowCount(len(data))
+        for row, item in enumerate(data):
+            self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(item["name"]))
+            self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(f"{item['balance']:.2f}"))
+            self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(item["status"]))
+        self.table.resizeColumnsToContents()
+        self._data = data
+
+    def _export(self) -> None:
+        if not getattr(self, "_data", None):
+            return
+        df = pd.DataFrame(self._data)
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Export", filter="Excel Files (*.xlsx)")
+        if path:
+            try:
+                df.to_excel(path, index=False)
+            except Exception as exc:  # pragma: no cover
+                QtWidgets.QMessageBox.critical(self, "Error", str(exc))

--- a/ggs_accounting/ui/settings_panel.py
+++ b/ggs_accounting/ui/settings_panel.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from PyQt6 import QtWidgets
+
+from ggs_accounting.db.db_manager import DatabaseManager
+
+
+class SettingsPanel(QtWidgets.QWidget):
+    """Panel for editing simple application settings."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        super().__init__()
+        self._db = db
+        self._init_ui()
+        self._load_settings()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QFormLayout(self)
+        self.company_edit = QtWidgets.QLineEdit()
+        self.address_edit = QtWidgets.QLineEdit()
+        save_btn = QtWidgets.QPushButton("Save")
+        save_btn.clicked.connect(self._save_settings)
+        layout.addRow("Company Name", self.company_edit)
+        layout.addRow("Address", self.address_edit)
+        layout.addRow(save_btn)
+
+    def _load_settings(self) -> None:
+        self.company_edit.setText(self._db.get_setting("company_name") or "")
+        self.address_edit.setText(self._db.get_setting("company_address") or "")
+
+    def _save_settings(self) -> None:
+        try:
+            self._db.set_setting("company_name", self.company_edit.text().strip())
+            self._db.set_setting(
+                "company_address", self.address_edit.text().strip()
+            )
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            return
+        QtWidgets.QMessageBox.information(self, "Saved", "Settings updated")

--- a/main.py
+++ b/main.py
@@ -32,13 +32,14 @@ def main():
         return
 
     app = QtWidgets.QApplication([])
+    QtWidgets.QApplication.setStyle("Fusion")
     while True:
         login = LoginDialog(db)
         if login.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             if login.user_role is None:
                 print("Login failed: user role is None.")
                 continue
-            window = MainWindow(login.user_role)
+            window = MainWindow(db, login.user_role)
             # Track if exit was requested
             exit_flag = {'exit': False}
             def set_exit():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "PyQt6",
     "pytest",
     "pydantic",
+    "reportlab",
+    "pandas",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -4,6 +4,7 @@ QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
 
 from ggs_accounting.ui.main_window import MainWindow
 from ggs_accounting.models.auth import UserRole
+from ggs_accounting.db.db_manager import DatabaseManager
 
 
 def ensure_app():
@@ -11,23 +12,30 @@ def ensure_app():
         QtWidgets.QApplication([])
 
 
+def create_manager(tmp_path):
+    mgr = DatabaseManager(tmp_path / "test.sqlite")
+    mgr.init_db()
+    return mgr
+
+
 def test_admin_sees_settings_tab(tmp_path):
     ensure_app()
-    win = MainWindow(UserRole.ADMIN.value)
+    win = MainWindow(create_manager(tmp_path), UserRole.ADMIN.value)
     tabs = [win._stack.tabText(i) for i in range(win._stack.count())]
     assert "Settings" in tabs
+    assert "SQL" in tabs
 
 
 def test_accountant_hides_settings(tmp_path):
     ensure_app()
-    win = MainWindow(UserRole.ACCOUNTANT.value)
+    win = MainWindow(create_manager(tmp_path), UserRole.ACCOUNTANT.value)
     tabs = [win._stack.tabText(i) for i in range(win._stack.count())]
     assert "Settings" not in tabs
 
 
 def test_logout_signal_emitted(tmp_path):
     ensure_app()
-    win = MainWindow(UserRole.ADMIN.value)
+    win = MainWindow(create_manager(tmp_path), UserRole.ADMIN.value)
     triggered = []
     win.logout_requested.connect(lambda: triggered.append(True))
     win._handle_logout()

--- a/tests/test_party_dialog.py
+++ b/tests/test_party_dialog.py
@@ -1,0 +1,28 @@
+import pytest
+
+QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.ui.party_dialog import PartyDialog
+
+
+def create_manager(tmp_path):
+    mgr = DatabaseManager(tmp_path / "test.sqlite")
+    mgr.init_db()
+    return mgr
+
+
+def ensure_app():
+    if QtWidgets.QApplication.instance() is None:
+        QtWidgets.QApplication([])
+
+
+def test_party_dialog_adds_party(tmp_path):
+    ensure_app()
+    mgr = create_manager(tmp_path)
+    dlg = PartyDialog(mgr)
+    dlg.name_edit.setText("Vendor")
+    dlg.contact_edit.setText("info")
+    dlg.accept()
+    parties = mgr.get_all_parties()
+    assert any(p["name"] == "Vendor" for p in parties)

--- a/tests/test_receipt_printer.py
+++ b/tests/test_receipt_printer.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+
+QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.printing.print_receipts import ReceiptPrinter
+
+
+def create_manager(tmp_path):
+    mgr = DatabaseManager(tmp_path / "test.sqlite")
+    mgr.init_db()
+    return mgr
+
+
+def ensure_app():
+    if QtWidgets.QApplication.instance() is None:
+        QtWidgets.QApplication([])
+
+
+def test_summary_pdf(tmp_path):
+    ensure_app()
+    mgr = create_manager(tmp_path)
+    item = mgr.add_item("Apple", "Fruit", 10.0, 5)
+    party = mgr.add_party("Cust")
+    mgr.create_invoice(
+        "2024-01-01",
+        "Sale",
+        party,
+        [{"item_id": item, "quantity": 2, "price": 10.0}],
+    )
+    printer = ReceiptPrinter(mgr)
+    invoices = printer.fetch_invoices("2024-01-01", "2024-01-02", None, None)
+    pdf = printer.print_summary(invoices)
+    assert os.path.exists(pdf)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.models import reporting
+
+
+def create_manager(tmp_path):
+    mgr = DatabaseManager(tmp_path / "test.sqlite")
+    mgr.init_db()
+    return mgr
+
+
+def test_run_raw_query(tmp_path):
+    mgr = create_manager(tmp_path)
+    mgr.add_party("Cust")
+    cols, rows = mgr.run_raw_query("SELECT name FROM Parties")
+    assert cols == ["name"]
+    assert rows[0][0] == "Cust"
+
+
+def test_run_raw_query_rejects_dml(tmp_path):
+    mgr = create_manager(tmp_path)
+    with pytest.raises(ValueError):
+        mgr.run_raw_query("DELETE FROM Parties")
+
+
+def test_party_balance_logic(tmp_path):
+    mgr = create_manager(tmp_path)
+    pid = mgr.add_party("A")
+    mgr.update_party_balance(pid, 50)
+    data = reporting.get_party_balances(mgr)
+    assert data[0]["status"] == "Receivable"
+
+
+def test_inventory_value(tmp_path):
+    mgr = create_manager(tmp_path)
+    mgr.add_item("Item", "cat", 2.0, 5)
+    data, total = reporting.get_inventory_values(mgr)
+    assert total == 10.0

--- a/tests/test_settings_panel.py
+++ b/tests/test_settings_panel.py
@@ -1,0 +1,28 @@
+import pytest
+
+QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
+
+from ggs_accounting.db.db_manager import DatabaseManager
+from ggs_accounting.ui.settings_panel import SettingsPanel
+
+
+def create_manager(tmp_path):
+    mgr = DatabaseManager(tmp_path / "test.sqlite")
+    mgr.init_db()
+    return mgr
+
+
+def ensure_app():
+    if QtWidgets.QApplication.instance() is None:
+        QtWidgets.QApplication([])
+
+
+def test_save_settings(tmp_path):
+    ensure_app()
+    mgr = create_manager(tmp_path)
+    panel = SettingsPanel(mgr)
+    panel.company_edit.setText("MyCo")
+    panel.address_edit.setText("123 Road")
+    panel._save_settings()
+    assert mgr.get_setting("company_name") == "MyCo"
+    assert mgr.get_setting("company_address") == "123 Road"


### PR DESCRIPTION
## Summary
- implement SQL reporting helpers and saved query execution
- add party dialog and settings panel
- provide receipt printing with summary or detailed PDFs
- show modern UI tabs including reporting and receipts
- revert requirements file to avoid binary diff

## Testing
- `pip install -e .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857b82a36c883249ee13ad9c2a93e95