### PR TITLE
Add customer categories and remove party naming

### DIFF
--- a/ggs_accounting/db/database.py
+++ b/ggs_accounting/db/database.py
@@ -14,39 +14,40 @@ CREATE_TABLE_QUERIES = [
         role TEXT NOT NULL
     )""",
     """CREATE TABLE IF NOT EXISTS Items(
-        item_id INTEGER PRIMARY KEY AUTOINCREMENT,
         name TEXT NOT NULL,
-        category TEXT,
-        grower_id INTEGER,
+        grower_id INTEGER NOT NULL,
         price_excl_tax REAL NOT NULL,
         stock_qty REAL NOT NULL DEFAULT 0,
-        FOREIGN KEY(grower_id) REFERENCES Parties(party_id)
+        PRIMARY KEY(name, grower_id),
+        FOREIGN KEY(grower_id) REFERENCES Customers(customer_id)
     )""",
-    """CREATE TABLE IF NOT EXISTS Parties(
-        party_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    """CREATE TABLE IF NOT EXISTS Customers(
+        customer_id INTEGER PRIMARY KEY AUTOINCREMENT,
         name TEXT NOT NULL,
         contact_info TEXT,
+        customer_type TEXT NOT NULL,
         balance REAL NOT NULL DEFAULT 0
     )""",
     """CREATE TABLE IF NOT EXISTS Invoices(
         inv_id INTEGER PRIMARY KEY AUTOINCREMENT,
         date TEXT NOT NULL,
         type TEXT NOT NULL,
-        party_id INTEGER,
+        customer_id INTEGER,
         subtotal REAL NOT NULL,
         total_amount REAL NOT NULL,
         is_credit INTEGER NOT NULL DEFAULT 0,
-        FOREIGN KEY(party_id) REFERENCES Parties(party_id)
+        FOREIGN KEY(customer_id) REFERENCES Customers(customer_id)
     )""",
     """CREATE TABLE IF NOT EXISTS InvoiceItems(
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         inv_id INTEGER NOT NULL,
-        item_id INTEGER NOT NULL,
+        item_name TEXT NOT NULL,
+        grower_id INTEGER NOT NULL,
         quantity REAL NOT NULL,
         unit_price REAL NOT NULL,
         line_total REAL NOT NULL,
         FOREIGN KEY(inv_id) REFERENCES Invoices(inv_id),
-        FOREIGN KEY(item_id) REFERENCES Items(item_id)
+        FOREIGN KEY(item_name, grower_id) REFERENCES Items(name, grower_id)
     )""",
     """CREATE TABLE IF NOT EXISTS Settings(
         key TEXT PRIMARY KEY,

--- a/ggs_accounting/models/invoice_logic.py
+++ b/ggs_accounting/models/invoice_logic.py
@@ -15,7 +15,7 @@ class InvoiceLogic:
     def create_invoice(
         self,
         inv_type: str,
-        party_id: Optional[int],
+        customer_id: Optional[int],
         items: List[Dict[str, Any]],
         *,
         date: Optional[str] = None,
@@ -27,12 +27,12 @@ class InvoiceLogic:
         inv_id = self._db.create_invoice(
             date_str,
             inv_type,
-            party_id,
+            customer_id,
             items,
             is_credit=is_credit,
         )
         for item in items:
             change = item["quantity"] if inv_type == "Purchase" else -item["quantity"]
-            self._db.update_item_stock(item["item_id"], change)
+            self._db.update_item_stock(item["name"], item["grower_id"], change)
         return inv_id
 

--- a/ggs_accounting/models/reporting.py
+++ b/ggs_accounting/models/reporting.py
@@ -6,26 +6,26 @@ from ggs_accounting.db.db_manager import DatabaseManager
 
 
 BUILT_IN_QUERIES: dict[str, str] = {
-    "Outstanding Balances": "SELECT name, balance FROM Parties WHERE balance <> 0",
+    "Outstanding Balances": "SELECT name, balance FROM Customers WHERE balance <> 0",
     "Top Selling Items": (
-        "SELECT item_id, SUM(quantity) AS total_sold\n"
+        "SELECT item_name, grower_id, SUM(quantity) AS total_sold\n"
         "FROM InvoiceItems\n"
         "JOIN Invoices ON Invoices.inv_id = InvoiceItems.inv_id\n"
         "WHERE Invoices.date >= date('now', '-30 days') AND Invoices.type = 'Sale'\n"
-        "GROUP BY item_id\n"
+        "GROUP BY item_name, grower_id\n"
         "ORDER BY total_sold DESC"
     ),
-    "Low Stock Items": "SELECT item_name AS name, stock_qty FROM Items WHERE stock_qty < 10",
+    "Low Stock Items": "SELECT name, grower_id, stock_qty FROM Items WHERE stock_qty < 10",
     "Recent Sales": (
         "SELECT date, total_amount FROM Invoices\n"
         "WHERE type = 'Sale'\n"
         "ORDER BY date DESC LIMIT 10"
     ),
     "High Value Customers": (
-        "SELECT Parties.name, SUM(Invoices.total_amount) as total_spent\n"
-        "FROM Invoices JOIN Parties ON Invoices.party_id = Parties.party_id\n"
+        "SELECT Customers.name, SUM(Invoices.total_amount) as total_spent\n"
+        "FROM Invoices JOIN Customers ON Invoices.customer_id = Customers.customer_id\n"
         "WHERE Invoices.type = 'Sale'\n"
-        "GROUP BY Parties.name\n"
+        "GROUP BY Customers.name\n"
         "ORDER BY total_spent DESC"
     ),
 }
@@ -36,9 +36,9 @@ def run_query(db: DatabaseManager, sql: str) -> Tuple[List[str], List[tuple]]:
     return db.run_raw_query(sql)
 
 
-def get_party_balances(db: DatabaseManager) -> List[Dict[str, Any]]:
+def get_customer_balances(db: DatabaseManager) -> List[Dict[str, Any]]:
     cur = db.conn.cursor()
-    cur.execute("SELECT name, balance FROM Parties")
+    cur.execute("SELECT name, balance FROM Customers")
     rows = cur.fetchall()
     result: List[Dict[str, Any]] = []
     for row in rows:

--- a/ggs_accounting/ui/main_window.py
+++ b/ggs_accounting/ui/main_window.py
@@ -55,7 +55,7 @@ class MainWindow(QtWidgets.QMainWindow):
         from .invoice_panel import InvoicePanel
         from .receipt_console import ReceiptConsole
         from .reports_panel import ReportsPanel
-        from .reports_party_balance import PartyBalancePanel
+        from .reports_party_balance import CustomerBalancePanel
         from .reports_inventory import InventoryValuationPanel
         from .settings_panel import SettingsPanel
 
@@ -63,7 +63,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._stack.addTab(InvoicePanel(self._db), "Billing")
         self._stack.addTab(ReceiptConsole(self._db), "Receipts")
         self._stack.addTab(ReportsPanel(self._db), "SQL")
-        self._stack.addTab(PartyBalancePanel(self._db), "Party Balances")
+        self._stack.addTab(CustomerBalancePanel(self._db), "Customer Balances")
         self._stack.addTab(InventoryValuationPanel(self._db), "Inventory Value")
         self._stack.addTab(self._create_placeholder("Backup"), "Backup")
 

--- a/ggs_accounting/ui/party_dialog.py
+++ b/ggs_accounting/ui/party_dialog.py
@@ -3,13 +3,13 @@ from PyQt6 import QtWidgets
 from ggs_accounting.db.db_manager import DatabaseManager
 
 
-class PartyDialog(QtWidgets.QDialog):
-    """Dialog for adding a new party."""
+class CustomerDialog(QtWidgets.QDialog):
+    """Dialog for adding a new customer."""
 
     def __init__(self, db: DatabaseManager) -> None:
         super().__init__()
         self._db = db
-        self.setWindowTitle("Add Party")
+        self.setWindowTitle("Add Customer")
 
         self.name_edit = QtWidgets.QLineEdit()
         self.contact_edit = QtWidgets.QLineEdit()
@@ -35,7 +35,7 @@ class PartyDialog(QtWidgets.QDialog):
             QtWidgets.QMessageBox.warning(self, "Validation", "Name required")
             return
         try:
-            self._db.add_party(name, self.contact_edit.text().strip())
+            self._db.add_customer(name, self.contact_edit.text().strip())
         except Exception as exc:  # pragma: no cover - unexpected errors
             QtWidgets.QMessageBox.critical(self, "Error", str(exc))
             return

--- a/ggs_accounting/ui/receipt_console.py
+++ b/ggs_accounting/ui/receipt_console.py
@@ -17,7 +17,7 @@ class ReceiptConsole(QtWidgets.QWidget):
         self._db = db
         self._printer = ReceiptPrinter(db)
         self._init_ui()
-        self._load_parties()
+        self._load_customers()
 
     def _init_ui(self) -> None:
         layout = QtWidgets.QVBoxLayout(self)
@@ -38,7 +38,7 @@ class ReceiptConsole(QtWidgets.QWidget):
 
         form.addRow("From", self.from_date)
         form.addRow("To", self.to_date)
-        form.addRow("Party", self.party_combo)
+        form.addRow("Customer", self.party_combo)
         form.addRow("Type", self.type_combo)
         form.addRow("Format", self.format_combo)
         layout.addLayout(form)
@@ -59,16 +59,16 @@ class ReceiptConsole(QtWidgets.QWidget):
             header.setStretchLastSection(True)
         layout.addWidget(self.summary_table)
 
-    def _load_parties(self) -> None:
+    def _load_customers(self) -> None:
         self.party_combo.clear()
         self.party_combo.addItem("All", None)
         try:
-            parties = self._db.get_all_parties()
+            parties = self._db.get_all_customers()
         except Exception as exc:  # pragma: no cover
             QtWidgets.QMessageBox.critical(self, "Error", str(exc))
             return
         for p in parties:
-            self.party_combo.addItem(p["name"], p["party_id"])
+            self.party_combo.addItem(p["name"], p["customer_id"])
 
     def _fetch(self) -> list:
         start = self.from_date.date().toString("yyyy-MM-dd")
@@ -82,11 +82,11 @@ class ReceiptConsole(QtWidgets.QWidget):
     def _show(self) -> None:
         invoices = self._fetch()
         self.summary_table.setRowCount(len(invoices))
-        parties = {p["party_id"]: p["name"] for p in self._db.get_all_parties()}
+        parties = {p["customer_id"]: p["name"] for p in self._db.get_all_customers()}
         for row, inv in enumerate(invoices):
             self.summary_table.setItem(row, 0, QtWidgets.QTableWidgetItem(inv["date"]))
             self.summary_table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(inv["inv_id"])))
-            self.summary_table.setItem(row, 2, QtWidgets.QTableWidgetItem(parties.get(inv["party_id"], "")))
+            self.summary_table.setItem(row, 2, QtWidgets.QTableWidgetItem(parties.get(inv["customer_id"], "")))
             self.summary_table.setItem(row, 3, QtWidgets.QTableWidgetItem(f"₹{inv['total_amount']:.2f}"))
         self.summary_table.resizeColumnsToContents()
 

--- a/ggs_accounting/ui/reports_party_balance.py
+++ b/ggs_accounting/ui/reports_party_balance.py
@@ -4,11 +4,11 @@ from PyQt6 import QtWidgets
 import pandas as pd
 
 from ggs_accounting.db.db_manager import DatabaseManager
-from ggs_accounting.models.reporting import get_party_balances
+from ggs_accounting.models.reporting import get_customer_balances
 
 
-class PartyBalancePanel(QtWidgets.QWidget):
-    """Display party-wise outstanding balances."""
+class CustomerBalancePanel(QtWidgets.QWidget):
+    """Display customer-wise outstanding balances."""
 
     def __init__(self, db: DatabaseManager) -> None:
         super().__init__()
@@ -28,7 +28,7 @@ class PartyBalancePanel(QtWidgets.QWidget):
         layout.addLayout(btns)
 
         self.table = QtWidgets.QTableWidget(0, 3)
-        self.table.setHorizontalHeaderLabels(["Party", "Balance", "Status"])
+        self.table.setHorizontalHeaderLabels(["Customer", "Balance", "Status"])
         self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
         header = self.table.horizontalHeader()
         if header is not None:
@@ -37,7 +37,7 @@ class PartyBalancePanel(QtWidgets.QWidget):
 
     def _load_data(self) -> None:
         try:
-            data = get_party_balances(self._db)
+            data = get_customer_balances(self._db)
         except Exception as exc:  # pragma: no cover
             QtWidgets.QMessageBox.critical(self, "Error", str(exc))
             return

--- a/ggs_accounting/utils.py
+++ b/ggs_accounting/utils.py
@@ -1,6 +1,11 @@
 import hashlib
 
 
+def camel_case(text: str) -> str:
+    """Convert a string to camel case words."""
+    return " ".join(word.capitalize() for word in text.split())
+
+
 def hash_password(password: str) -> str:
     return hashlib.sha256(password.encode('utf-8')).hexdigest()
 

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -17,30 +17,32 @@ def test_init_creates_tables_and_admin(tmp_path):
 
 def test_item_crud(tmp_path):
     mgr = create_manager(tmp_path)
-    item_id = mgr.add_item("Apple", "Fruit", 10.0, 5)
+    grower_id = mgr.add_customer("Grower", customer_type="Grower")
+    mgr.add_item("Apple", 10.0, 5, grower_id=grower_id)
     items = mgr.get_all_items()
-    assert any(i["item_id"] == item_id for i in items)
-    mgr.update_item(item_id, stock_qty=10)
+    assert any(i["name"] == "Apple" for i in items)
+    mgr.update_item("Apple", 1, stock_qty=10)
     assert mgr.get_all_items()[0]["stock_qty"] == 10
-    mgr.delete_item(item_id)
+    mgr.delete_item("Apple", 1)
     assert mgr.get_all_items() == []
 
 
 def test_create_invoice(tmp_path):
     mgr = create_manager(tmp_path)
-    item_id = mgr.add_item("Apple", "Fruit", 10.0, 5)
-    party_id = mgr.add_party("Customer")
+    grower_id = mgr.add_customer("Grower", customer_type="Grower")
+    mgr.add_item("Apple", 10.0, 5, grower_id=grower_id)
+    customer_id = mgr.add_customer("Customer")
     inv_id = mgr.create_invoice(
         "2024-01-01",
         "Sale",
-        party_id,
-        [{"item_id": item_id, "quantity": 2, "price": 10.0}],
+        customer_id,
+        [{"name": "Apple", "grower_id": grower_id, "quantity": 2, "price": 10.0}],
         is_credit=True,
     )
     assert any(inv["inv_id"] == inv_id for inv in mgr.get_invoices())
     items = mgr.get_invoice_items(inv_id)
     assert items[0]["quantity"] == 2
-    bal = mgr.conn.execute("SELECT balance FROM Parties WHERE party_id=?", (party_id,)).fetchone()[0]
+    bal = mgr.conn.execute("SELECT balance FROM Customers WHERE customer_id=?", (customer_id,)).fetchone()[0]
     assert bal > 0
 
 

--- a/tests/test_invoice_logic.py
+++ b/tests/test_invoice_logic.py
@@ -14,18 +14,19 @@ def create_manager(tmp_path):
 
 def test_invoice_logic_updates_stock(tmp_path):
     mgr = create_manager(tmp_path)
-    item_id = mgr.add_item("Banana", "Fruit", 5.0, 10)
-    party_id = mgr.add_party("Customer")
+    grower_id = mgr.add_customer("Grower", customer_type="Grower")
+    mgr.add_item("Banana", 5.0, 10, grower_id=grower_id)
+    customer_id = mgr.add_customer("Customer")
     logic = InvoiceLogic(mgr)
     logic.create_invoice(
         "Sale",
-        party_id,
-        [{"item_id": item_id, "quantity": 4, "price": 5.0}],
+        customer_id,
+        [{"name": "Banana", "grower_id": grower_id, "quantity": 4, "price": 5.0}],
         date="2024-01-02",
         is_credit=True,
     )
-    qty = mgr.conn.execute("SELECT stock_qty FROM Items WHERE item_id=?", (item_id,)).fetchone()[0]
+    qty = mgr.conn.execute("SELECT stock_qty FROM Items WHERE name=? AND grower_id=?", ("Banana", grower_id)).fetchone()[0]
     assert qty == 6
-    bal = mgr.conn.execute("SELECT balance FROM Parties WHERE party_id=?", (party_id,)).fetchone()[0]
+    bal = mgr.conn.execute("SELECT balance FROM Customers WHERE customer_id=?", (customer_id,)).fetchone()[0]
     assert bal == 20.0
 

--- a/tests/test_party_dialog.py
+++ b/tests/test_party_dialog.py
@@ -3,7 +3,7 @@ import pytest
 QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
 
 from ggs_accounting.db.db_manager import DatabaseManager
-from ggs_accounting.ui.party_dialog import PartyDialog
+from ggs_accounting.ui.party_dialog import CustomerDialog
 
 
 def create_manager(tmp_path):
@@ -20,9 +20,9 @@ def ensure_app():
 def test_party_dialog_adds_party(tmp_path):
     ensure_app()
     mgr = create_manager(tmp_path)
-    dlg = PartyDialog(mgr)
-    dlg.name_edit.setText("Vendor")
+    dlg = CustomerDialog(mgr)
+    dlg.name_edit.setText("vendor name")
     dlg.contact_edit.setText("info")
     dlg.accept()
-    parties = mgr.get_all_parties()
-    assert any(p["name"] == "Vendor" for p in parties)
+    parties = mgr.get_all_customers()
+    assert any(p["name"] == "Vendor Name" for p in parties)

--- a/tests/test_receipt_printer.py
+++ b/tests/test_receipt_printer.py
@@ -21,13 +21,14 @@ def ensure_app():
 def test_summary_pdf(tmp_path):
     ensure_app()
     mgr = create_manager(tmp_path)
-    item = mgr.add_item("Apple", "Fruit", 10.0, 5)
-    party = mgr.add_party("Cust")
+    grower_id = mgr.add_customer("Grower", customer_type="Grower")
+    mgr.add_item("Apple", 10.0, 5, grower_id=grower_id)
+    customer = mgr.add_customer("Cust")
     mgr.create_invoice(
         "2024-01-01",
         "Sale",
-        party,
-        [{"item_id": item, "quantity": 2, "price": 10.0}],
+        customer,
+        [{"name": "Apple", "grower_id": grower_id, "quantity": 2, "price": 10.0}],
     )
     printer = ReceiptPrinter(mgr)
     invoices = printer.fetch_invoices("2024-01-01", "2024-01-02", None, None)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -12,8 +12,8 @@ def create_manager(tmp_path):
 
 def test_run_raw_query(tmp_path):
     mgr = create_manager(tmp_path)
-    mgr.add_party("Cust")
-    cols, rows = mgr.run_raw_query("SELECT name FROM Parties")
+    mgr.add_customer("Cust")
+    cols, rows = mgr.run_raw_query("SELECT name FROM Customers")
     assert cols == ["name"]
     assert rows[0][0] == "Cust"
 
@@ -21,19 +21,20 @@ def test_run_raw_query(tmp_path):
 def test_run_raw_query_rejects_dml(tmp_path):
     mgr = create_manager(tmp_path)
     with pytest.raises(ValueError):
-        mgr.run_raw_query("DELETE FROM Parties")
+        mgr.run_raw_query("DELETE FROM Customers")
 
 
 def test_party_balance_logic(tmp_path):
     mgr = create_manager(tmp_path)
-    pid = mgr.add_party("A")
-    mgr.update_party_balance(pid, 50)
-    data = reporting.get_party_balances(mgr)
+    pid = mgr.add_customer("A")
+    mgr.update_customer_balance(pid, 50)
+    data = reporting.get_customer_balances(mgr)
     assert data[0]["status"] == "Receivable"
 
 
 def test_inventory_value(tmp_path):
     mgr = create_manager(tmp_path)
-    mgr.add_item("Item", "cat", 2.0, 5)
+    grower = mgr.add_customer("Grower", customer_type="Grower")
+    mgr.add_item("Item", 2.0, 5, grower_id=grower)
     data, total = reporting.get_inventory_values(mgr)
     assert total == 10.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,7 @@
+import pytest
+from ggs_accounting.utils import camel_case
+
+
+def test_camel_case():
+    assert camel_case("john doe") == "John Doe"
+    assert camel_case("APPLE") == "Apple"


### PR DESCRIPTION
## Summary
- rename Parties to Customers in schema and code
- add `customer_type` and helper to filter by type
- drop item categories and use grower IDs
- update UI labels and dialogs for customers
- adjust tests to new API

## Testing
- `pip install -e .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857d31833fc8324bb2b30bdfe9ad8ae