### PR TITLE
Add customer-based inventory valuation options

### DIFF
--- a/ggs_accounting/ui/inventory_panel.py
+++ b/ggs_accounting/ui/inventory_panel.py
@@ -108,7 +108,9 @@ class InventoryPanel(QtWidgets.QWidget):
         super().__init__()
         self._db = db
         self._items: List[Dict[str, Any]] = []
+        self._customers: List[Dict[str, Any]] = []
         self._init_ui()
+        self._load_customers()
         self._load_items()
 
     def _init_ui(self) -> None:
@@ -145,7 +147,16 @@ class InventoryPanel(QtWidgets.QWidget):
             layout.addWidget(note)
 
     # ---- UI helpers ----
+    def _load_customers(self) -> None:
+        """Load growers for customer lookups."""
+        try:
+            self._customers = self._db.get_customers_by_type("Grower")
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            self._customers = []
+
     def _load_items(self) -> None:
+        self._load_customers()
         try:
             self._items = self._db.get_all_items()
         except Exception as exc:  # pragma: no cover - unexpected errors

--- a/ggs_accounting/ui/reports_inventory.py
+++ b/ggs_accounting/ui/reports_inventory.py
@@ -13,7 +13,10 @@ class InventoryValuationPanel(QtWidgets.QWidget):
     def __init__(self, db: DatabaseManager) -> None:
         super().__init__()
         self._db = db
+        self._items = []
+        self._customers = []
         self._init_ui()
+        self._load_filters()
         self._load_data()
 
     def _init_ui(self) -> None:
@@ -27,6 +30,15 @@ class InventoryValuationPanel(QtWidgets.QWidget):
         btns.addWidget(export_btn)
         layout.addLayout(btns)
 
+        filters = QtWidgets.QHBoxLayout()
+        self.item_combo = QtWidgets.QComboBox()
+        self.customer_combo = QtWidgets.QComboBox()
+        self.item_combo.currentIndexChanged.connect(self._load_data)
+        self.customer_combo.currentIndexChanged.connect(self._load_data)
+        filters.addWidget(self.item_combo)
+        filters.addWidget(self.customer_combo)
+        layout.addLayout(filters)
+
         self.table = QtWidgets.QTableWidget(0, 4)
         self.table.setHorizontalHeaderLabels(["Item", "Stock", "Price (₹)", "Value (₹)"])
         self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
@@ -38,9 +50,32 @@ class InventoryValuationPanel(QtWidgets.QWidget):
         self.total_label = QtWidgets.QLabel()
         layout.addWidget(self.total_label)
 
-    def _load_data(self) -> None:
+    def _load_filters(self) -> None:
         try:
-            data, total = get_inventory_values(self._db)
+            self._items = self._db.get_all_items()
+            self._customers = self._db.get_customers_by_type("Grower")
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            QtWidgets.QMessageBox.critical(self, "Error", str(exc))
+            self._items = []
+            self._customers = []
+        self.item_combo.clear()
+        self.item_combo.addItem("All Items", None)
+        added = set()
+        for it in self._items:
+            if it["item_id"] in added:
+                continue
+            added.add(it["item_id"])
+            self.item_combo.addItem(it["name"], it["item_id"])
+        self.customer_combo.clear()
+        self.customer_combo.addItem("All Customers", None)
+        for c in self._customers:
+            self.customer_combo.addItem(c["name"], c["customer_id"])
+
+    def _load_data(self) -> None:
+        item_id = self.item_combo.currentData()
+        customer_id = self.customer_combo.currentData()
+        try:
+            data, total = get_inventory_values(self._db, item_id=item_id, customer_id=customer_id)
         except Exception as exc:  # pragma: no cover
             QtWidgets.QMessageBox.critical(self, "Error", str(exc))
             return
@@ -51,7 +86,11 @@ class InventoryValuationPanel(QtWidgets.QWidget):
             self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(f"₹{item['price']:.2f}"))
             self.table.setItem(row, 3, QtWidgets.QTableWidgetItem(f"₹{item['value']:.2f}"))
         self.table.resizeColumnsToContents()
-        self.total_label.setText(f"Total Stock Value: ₹{total:.2f}")
+        total_stock = sum(d.get("stock", 0) for d in data)
+        total_price = sum(d.get("price", 0) for d in data)
+        self.total_label.setText(
+            f"Totals - Stock: {total_stock:.2f} Price: ₹{total_price:.2f} Value: ₹{total:.2f}"
+        )
         self._data = data
 
     def _export(self) -> None:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -38,3 +38,15 @@ def test_inventory_value(tmp_path):
     mgr.add_item("Item", "ITM", 2.0, 5, customer_id=customer_id)
     data, total = reporting.get_inventory_values(mgr)
     assert total == 10.0
+
+
+def test_inventory_value_by_customer(tmp_path):
+    mgr = create_manager(tmp_path)
+    c1 = mgr.add_customer("G1", customer_type="Grower")
+    c2 = mgr.add_customer("G2", customer_type="Grower")
+    mgr.add_item("Apple", "APL", 2.0, 5, customer_id=c1)
+    mgr.add_item("Banana", "BAN", 3.0, 4, customer_id=c2)
+    data, total = reporting.get_inventory_values(mgr, item_id=None)
+    names = {d["name"] for d in data}
+    assert names == {"G1", "G2"}
+    assert total == pytest.approx(5 * 2.0 + 4 * 3.0)


### PR DESCRIPTION
## Summary
- allow InventoryPanel to load grower list
- extend reporting.get_inventory_values with item/customer filters
- show item & customer filters in InventoryValuationPanel
- support buyer selection on invoices
- test inventory valuation by customer

## Testing
- `pip install -e .`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580448862483248b9c2d7bb081aeab